### PR TITLE
tiniproxy: Add new option to reflect changes of the tiniproxy upstrea…

### DIFF
--- a/net/tinyproxy/files/tinyproxy.init
+++ b/net/tinyproxy/files/tinyproxy.init
@@ -15,16 +15,18 @@ section_enabled() {
 
 write_upstream() {
 	local type
+	local proxytype
 	local via
 	local target
 
 	config_get "type" "$1" "type"
+	config_get "proxytype" "$1" "proxytype"
 	config_get via "$1" via
 	config_get target "$1" target
 	[ -n "$target" ] && target=' "'"$target"'"'
 
-	[ "$type" = "proxy" ] && [ -n "$via" ] && \
-		echo "upstream $via$target"
+	[ "$type" = "proxy" ] && [ -n "$via" ] && [ -n "$proxytype" ] && \
+		echo "upstream $proxytype $via$target"
 
 	[ "$type" = "reject" ] && [ -n "$target" ] && \
 		echo "no upstream$target"


### PR DESCRIPTION
…m option format

Add new option to reflect changes in the tiniproxy config
Now upstream proxies must be in the "upstream proxytype via target" format in the tiniproxy config file.
Lua luci file - tinyproxy.lua also need to be patched.
Signed-off-by: Andrey Belyakov <andvalb@gmail.com>

